### PR TITLE
Fix url_for masterclass profile to point to blueprint

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,7 +8,7 @@
         {% for masterclass in masterclasses %}
 
         <div class="app-content-panel">
-            <h2 class="govuk-heading-m"><a class="govuk-link--no-visited-state" href="{{ url_for('masterclass_profile', masterclass_id=masterclass.id) }}">{{ masterclass.content.name }}</a></h2>
+            <h2 class="govuk-heading-m"><a class="govuk-link--no-visited-state" href="{{ url_for('main_bp.masterclass_profile', masterclass_id=masterclass.id) }}">{{ masterclass.content.name }}</a></h2>
             <table>
                 <tr class="govuk-table__row">
                     <td class="govuk-caption-m govuk-!-padding-right-6">Location</td>


### PR DESCRIPTION
A fix to update the masterclass profile endpoint now that we are using a blueprint.