### PR TITLE
Add new masterclass content 

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, url_for, flash, redirect, request, Blueprint
+from flask import render_template, url_for, flash, redirect, request, Blueprint, session
 from flask_login import current_user, login_user, login_required, logout_user
 from app.models import *
 
@@ -61,3 +61,16 @@ def my_masterclasses():
     user = current_user
     booked_masterclasses = user.booked_masterclasses
     return render_template('my-masterclasses.html')
+
+
+@main_bp.route('/create-masterclass', methods=['GET', 'POST'])
+@login_required
+def create_masterclass_start():
+    if request.method == 'POST':
+        new_masterclass = Masterclass()
+        db.session.add(new_masterclass)
+        db.session.commit()
+        session['draft_masterclass_id'] = new_masterclass.id
+        return render_template('create-masterclass/content/choose-ddat-family.html')
+    return render_template('create-masterclass/start.html')
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, url_for, flash, redirect, request, Blueprint, session
+from flask import render_template, url_for, flash, redirect, request, Blueprint, session, Response
 from flask_login import current_user, login_user, login_required, logout_user
 from app.models import *
 
@@ -86,3 +86,22 @@ def choose_job_family():
         existing_masterclasses = MasterclassContent.query.filter_by(category=chosen_job_family)
         return render_template('create-masterclass/content/new-or-existing.html',  existing_masterclasses=existing_masterclasses)
 
+@main_bp.route('/create-masterclass/content/new-or-existing', methods=['GET', 'POST'])
+@login_required
+def choose_new_or_existing_content():
+    if request.method == 'POST':
+        choice = request.form['which-masterclass']
+        if choice =="new masterclass":
+            return render_template('create-masterclass/content/create-new.html')
+        else:
+            draft_masterclass = Masterclass.query.filter_by(id=session['draft_masterclass_id']).first()
+            draft_masterclass.masterclass_content_id = int(choice)
+            db.session.add(draft_masterclass)
+            db.session.commit()
+            return redirect(url_for('main_bp.index'))
+    elif request.method == 'GET':
+        chosen_job_family = session['job_family']
+        existing_masterclasses = MasterclassContent.query.filter_by(category=chosen_job_family)
+        return render_template('create-masterclass/content/new-or-existing.html', existing_masterclasses=existing_masterclasses)
+    else:
+        return Response(status_code=405) 

--- a/app/routes.py
+++ b/app/routes.py
@@ -113,7 +113,7 @@ def create_new_content():
             new_content = MasterclassContent(name = request.form['masterclass-name'], description = request.form['masterclass-description'])
             db.session.add(new_content) 
             db.session.commit()
-            draft_masterclass = Masterclass.query.filter_by(id=session['draft_masterclass_id']).first() 
+            draft_masterclass = Masterclass.query.get(session['draft_masterclass_id'])
             draft_masterclass.masterclass_content_id = new_content.id
             db.session.add(draft_masterclass)
             db.session.commit()

--- a/app/routes.py
+++ b/app/routes.py
@@ -105,3 +105,18 @@ def choose_new_or_existing_content():
         return render_template('create-masterclass/content/new-or-existing.html', existing_masterclasses=existing_masterclasses)
     else:
         return Response(status_code=405) 
+
+@main_bp.route('/create-masterclass/content/create-new', methods=['GET', 'POST'])
+@login_required
+def create_new_content():
+    if request.method == 'POST':
+            new_content = MasterclassContent(name = request.form['masterclass-name'], description = request.form['masterclass-description'])
+            db.session.add(new_content) 
+            db.session.commit()
+            draft_masterclass = Masterclass.query.filter_by(id=session['draft_masterclass_id']).first() 
+            draft_masterclass.masterclass_content_id = new_content.id
+            db.session.add(draft_masterclass)
+            db.session.commit()
+            return redirect(url_for('main_bp.index')) # TODO will take them back to task list page
+    else:
+        return render_template('create-masterclass/content/create-new.html')

--- a/app/routes.py
+++ b/app/routes.py
@@ -9,7 +9,7 @@ main_bp = Blueprint("main_bp", __name__)
 @main_bp.route('/index', methods=['GET'])
 @login_required
 def index():
-    masterclasses = Masterclass.query.order_by(Masterclass.timestamp.asc()).all()
+    masterclasses = Masterclass.query.filter_by(draft=None).order_by(Masterclass.timestamp.asc()).all()
     return render_template('index.html', title='Home', user=User, masterclasses=masterclasses)
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -74,3 +74,15 @@ def create_masterclass_start():
         return render_template('create-masterclass/content/choose-ddat-family.html')
     return render_template('create-masterclass/start.html')
 
+
+@main_bp.route('/create-masterclass/content/job-family', methods=['GET', 'POST'])
+@login_required
+def choose_job_family():
+    if request.method == 'GET':
+        return render_template('create-masterclass/content/choose-ddat-family.html')
+    elif request.method == 'POST':    
+        chosen_job_family = request.form['select-job-family']
+        session['job_family'] = chosen_job_family
+        existing_masterclasses = MasterclassContent.query.filter_by(category=chosen_job_family)
+        return render_template('create-masterclass/content/new-or-existing.html',  existing_masterclasses=existing_masterclasses)
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,7 +26,7 @@
             <nav>
                 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
                     <li class="govuk-header__navigation-item">
-                        <a class="govuk-header__link" href="/create-a-masterclass">
+                        <a class="govuk-header__link" href="/create-masterclass">
                             Create a masterclass
                         </a>
                     </li>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,8 +17,8 @@
                       <span class="govuk-header__logotype-text">
                       Masterclasses 
                       </span>
-            </a>
-            </span>
+                    </a>
+                </span>
             </a>
         </div>
         <div align="right" class="govuk-header__content">
@@ -26,23 +26,30 @@
             <nav>
                 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
                     <li class="govuk-header__navigation-item">
+                        <a class="govuk-header__link" href="/create-a-masterclass">
+                            Create a masterclass
+                        </a>
+                    </li>
+                    <li class="govuk-header__navigation-item">
                         <a class="govuk-header__link" href="#2">
-                      Upcoming
-                    </a>
+                            Upcoming
+                        </a>
                     </li>
                     <li class="govuk-header__navigation-item">
                         <a class="govuk-header__link" href="#3">
-                      My masterclasses
-                    </a>
+                            My masterclasses
+                        </a>
                     </li>
                     <li class="govuk-header__navigation-item">
                         {% if current_user.is_anonymous %}
                         <a class="govuk-header__link" href="{{ url_for('main_bp.login') }}">
-                      Login
-                    </a> {% else %}
+                            Login
+                        </a> 
+                        {% else %}
                         <a class="govuk-header__link" href="{{ url_for('main_bp.logout') }}">
-                      Logout
-                    </a> {% endif %}
+                            Logout
+                        </a> 
+                        {% endif %}
                     </li>
                 </ul>
             </nav>

--- a/app/templates/create-masterclass/content/choose-ddat-family.html
+++ b/app/templates/create-masterclass/content/choose-ddat-family.html
@@ -17,7 +17,7 @@
                 </h1>
               </legend>
               <span id="DDaT-job-family-link" class="govuk-hint">
-                <a href="https://www.gov.uk/government/collections/digital-data-and-technology-profession-capability-framework#data-job-family">Find out more about the job families</a>
+                <a href="https://www.gov.uk/government/collections/digital-data-and-technology-profession-capability-framework#data-job-family">Find out more about the DDaT job families</a>
               </span>
               {% include 'partials/ddat-job-family-radios.html' %}
             </fieldset>

--- a/app/templates/create-masterclass/content/choose-ddat-family.html
+++ b/app/templates/create-masterclass/content/choose-ddat-family.html
@@ -1,0 +1,34 @@
+{%  extends "base.html" %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <a href="/" class="govuk-back-link">Back</a>
+
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <form action="/create-masterclass/content/job-family" method="post" novalidate>
+
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                <h1 class="govuk-fieldset__heading">
+                  Which DDaT job family is your masterclass related to?
+                </h1>
+              </legend>
+              <span id="DDaT-job-family-link" class="govuk-hint">
+                <a href="https://www.gov.uk/government/collections/digital-data-and-technology-profession-capability-framework#data-job-family">Find out more about the job families</a>
+              </span>
+              {% include 'partials/ddat-job-family-radios.html' %}
+            </fieldset>
+          </div>
+
+          <button class="govuk-button" data-module="govuk-button">
+            Continue
+          </button>
+        </form>
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/app/templates/create-masterclass/content/create-new.html
+++ b/app/templates/create-masterclass/content/create-new.html
@@ -1,0 +1,44 @@
+{%  extends "base.html" %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <a href="/create-masterclass/content/new-or-existing" class="govuk-back-link">Back</a>
+
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Create new masterclass content</h1>
+        <form action="/create-masterclass/content/create-new" method="post" novalidate>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="event-name">
+                    Name
+                </label>
+                <span id="more-detail-hint" class="govuk-hint">
+                    Summarise as best you can what this masterclass will cover
+                </span>
+                <input class="govuk-input" id="masterclass-name" name="masterclass-name" type="text">
+            </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="more-detail">
+                    Description
+                </label>
+                <span id="more-detail-hint" class="govuk-hint">
+                    Describe what someone attending the masterclass would learn from it
+                </span>
+                <textarea class="govuk-textarea" id="masterclass-description" name="masterclass-description" rows="5" aria-describedby="masterclass-description"></textarea>
+                <label class="govuk-label" for="sort">
+                    Which DDaT job family is your masterclass related to?
+                </label>
+                </br>
+                {% include 'partials/ddat-job-family-radios.html' %}
+                </br>
+                <button class="govuk-button" data-module="govuk-button">
+                  Continue
+                </button>
+            </div>
+        </form>
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/app/templates/create-masterclass/content/new-or-existing.html
+++ b/app/templates/create-masterclass/content/new-or-existing.html
@@ -1,0 +1,51 @@
+{%  extends "base.html" %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <a href="/create-masterclass/content/job-family" class="govuk-back-link">Back</a>
+
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <form action="/create-masterclass/content/new-or-existing" method="post" novalidate>
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                <h1 class="govuk-fieldset__heading">
+                  Which masterclass do you want to run?
+                </h1>
+              </legend>
+              <span id="choose-masterclass-hint" class="govuk-hint">
+                Choose an existing masterclass to run or create a new one.
+              </span>
+              <div class="govuk-radios">
+                {% for masterclass in existing_masterclasses %}
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" id="existing-masterclass" name="which-masterclass" type="radio" value={{masterclass.id}}>
+                        <label class="govuk-label govuk-radios__label" for="select-job-family">
+                            {{masterclass.name}}
+                        </label>
+                        <span class="govuk-hint govuk-radios__hint">
+                            {{masterclass.description}}
+                        </span>
+                    </div>
+                 {% endfor %}
+                 <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" id="new_masterclass_option" name="which-masterclass" type="radio" value="new masterclass">
+                        <label class="govuk-label govuk-radios__label" for="select-job-family">
+                            I want to run a new masterclass
+                        </label>
+                  </div>
+              </div>
+            </fieldset>
+          </div>
+
+          <button class="govuk-button" data-module="govuk-button">
+            Continue
+          </button>
+        </form>
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/app/templates/create-masterclass/start.html
+++ b/app/templates/create-masterclass/start.html
@@ -1,0 +1,40 @@
+{%  extends "base.html" %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ url_for('main_bp.index') }}">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">Create a masterclass</li>
+    </ol>
+  </div>
+
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Create a masterclass</h1>
+        <p class="govuk-body">A masterclass is a workshop which helps to build digital, data and technology skills in civil servants. Any civil servant can run a masterclass.</p>
+        <p class="govuk-body">To create a new masterclass you will need to provide:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>a name and description</li>
+          <li>a time and date</li>
+          <li>a location</li>
+          <li>the number of available spaces</li>
+        </ul>
+
+        <p class="govuk-body">Creating a new masterclass takes around 5 minutes.</p>
+
+        <form class="govuk-form-group" action="/create-masterclass" method="post">
+          <div class="input submit">
+            <input type="submit" value="Start now" class="govuk-button">
+          </div>
+        </form>
+
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/app/templates/partials/ddat-job-family-radios.html
+++ b/app/templates/partials/ddat-job-family-radios.html
@@ -1,0 +1,38 @@
+<div class="govuk-radios">
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="select-job-family" name="select-job-family" type="radio" value="data">
+    <label class="govuk-label govuk-radios__label" for="select-job-family">
+      Data
+    </label>
+  </div>
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="select-job-family-2" name="select-job-family" type="radio" value="it operations">
+    <label class="govuk-label govuk-radios__label" for="select-job-family-2">
+      IT operations
+    </label>
+  </div>
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="select-job-family-3" name="select-job-family" type="radio" value="product and delivery">
+    <label class="govuk-label govuk-radios__label" for="select-job-family-3">
+      Product and delivery
+    </label>
+  </div>
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="select-job-family-4" name="select-job-family" type="radio" value="quality assurance testing">
+    <label class="govuk-label govuk-radios__label" for="select-job-family-4">
+      Quality assurance testing
+    </label>
+  </div>
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="select-job-family-5" name="select-job-family" type="radio" value="technical">
+    <label class="govuk-label govuk-radios__label" for="select-job-family-5">
+      Technical
+    </label>
+  </div>
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="select-job-family-6" name="select-job-family" type="radio" value="user-centred design">
+    <label class="govuk-label govuk-radios__label" for="select-job-family-6">
+      User-centred design
+    </label>
+  </div>
+</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==1.2.0
 attrs==19.3.0
+blinker==1.4
 Click==7.0
 Flask==1.1.1
 Flask-Login==0.4.1

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -30,13 +30,3 @@ def db(client):
     yield _db
 
     _db.drop_all()
-
-
-def test_login_not_required(client, db):
-    rv = client.get('/')
-    assert rv.status_code == 200
-
-
-def test_login_required(login_required_client):
-    rv = login_required_client.get('/')
-    assert rv.status_code == 302

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -65,6 +65,10 @@ def blank_session(db):
     session_.remove()
     print("Rolled back blank session")
 
+def test_chosen_job_family_is_added_to_session(logged_in_user, blank_session):
+    with logged_in_user.post('/create-masterclass/content/job-family', data = {'select-job-family': 'Data'}):
+        assert session['job_family'] == 'Data'
+
 def test_draft_masterclass_id_is_added_to_session(logged_in_user, blank_session):
     with logged_in_user.post('/create-masterclass'):
         assert session['draft_masterclass_id'] == 1

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -1,32 +1,70 @@
 import pytest
 
+from flask import session
 from app import create_app
 from app import db as _db
 from config import *
 
-
-@pytest.fixture
-def client():
+@pytest.fixture(scope="session")
+def test_app():
     app = create_app(TestConfig)
-    with app.test_client() as client:
-        yield client
+    yield app
 
+@pytest.fixture(scope="session", autouse=True)
+def test_client(test_app):
+
+    # Flask provides a way to test your application by exposing the Werkzeug test Client
+    # and handling the context locals for you.
+    testing_client = test_app.test_client()
+
+    # Establish an application context before running the tests.
+    ctx = test_app.test_request_context()
+    ctx.push()
+
+    yield testing_client  # this is where the testing happens!
+
+    ctx.pop()
 
 @pytest.fixture
-def login_required_client():
-    app = create_app(TestLoginConfig)
-    with app.test_client() as client:
-        yield client
+def logged_in_user(test_client):
+    with test_client:
+        test_client.post(
+            "main_bp.login", data={"email-address": "test@user.com", "password": "Password"}
+        )
+        yield test_client
+        test_client.get("main_bp.logout")
 
-
-@pytest.fixture
-def db(client):
+@pytest.fixture(scope="session")
+def db(test_client):
     """
     This takes the FlaskClient object and applies it to the database.app attribute. Once this fixture is finished with, it drops everything in there
     """
-    _db.app = client.application
+    _db.app = test_client.application
     _db.create_all()
 
     yield _db
 
     _db.drop_all()
+
+
+@pytest.fixture(scope="function", autouse=False)
+def blank_session(db):
+    connection = db.engine.connect()
+    transaction = connection.begin()
+
+    options = dict(bind=connection, binds={})
+    session_ = db.create_scoped_session(options=options)
+
+    db.session = session_
+
+    print("Yielding blank session")
+    yield session_
+
+    transaction.rollback()
+    connection.close()
+    session_.remove()
+    print("Rolled back blank session")
+
+def test_draft_masterclass_id_is_added_to_session(logged_in_user, blank_session):
+    with logged_in_user.post('/create-masterclass'):
+        assert session['draft_masterclass_id'] == 1


### PR DESCRIPTION
This PR adds the first part of the 'Create a masterclass' journey. It allows users to choose the content of their masterclass, i.e. a related DDaT job family, a name and a description. 

When a user clicks 'Start now' on the start page, a draft masterclass is created with just an id. This id is stored in the session and accessed in order to add either existing masterclass content to the draft masterclass, or new masterclass content. This approach was chosen over storing data from each section of the 'Create a masterclass' journey in the session and creating a new masterclass at the end of the journey, so as to avoid the user losing data they had already entered. 

The draft masterclass is created by clicking start now, rather than before or after this point, so as to both reduce the number of incomplete draft masterclasses in the databases and to avoid a user losing too much of their data by doing it later on in the process.

**TODO**
Another PR is to follow which updates the logged_in_user fixture to actually be logged in, as well as additional tests to check that a user cannot access certain routes unless they are logged in.

**Screenshots**
1. Start create masterclass journey
![Screenshot 2020-06-29 at 21 50 05](https://user-images.githubusercontent.com/22460823/86054683-80403e80-ba52-11ea-9159-9dceaef8dd3d.png)

2. Choose a DDaT job family
![Screenshot 2020-06-29 at 21 50 27](https://user-images.githubusercontent.com/22460823/86054715-8df5c400-ba52-11ea-8440-d7f7e536de2d.png)

3. Chose existing masterclass content or create new
![Screenshot 2020-06-29 at 21 50 49](https://user-images.githubusercontent.com/22460823/86054751-9b12b300-ba52-11ea-9833-71d925ea1ab5.png)

4. Create new masterclass content
<img width="737" alt="Screenshot 2020-07-01 at 22 07 40" src="https://user-images.githubusercontent.com/22460823/86291697-49e7f800-bbe7-11ea-8ee3-b95d1869b726.png">

