### PR TITLE
Update login required tests

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -35,8 +35,8 @@ def logout():
     return redirect(url_for('index'))
 
 
-@login_required
 @main_bp.route('/masterclass/<masterclass_id>', methods=['GET', 'POST'])
+@login_required
 def masterclass_profile(masterclass_id):
     masterclass = Masterclass.query.get(masterclass_id)
     already_attendee = MasterclassAttendee.is_attendee(current_user.id, masterclass_id)
@@ -48,15 +48,15 @@ def masterclass_profile(masterclass_id):
     return render_template('masterclass-profile.html', masterclass_data=masterclass, already_attendee=already_attendee)
 
 
-@login_required
 @main_bp.route('/signup-confirmation', methods=['GET'])
+@login_required
 def signup_confirmation():
     masterclass = Masterclass.query.get(request.args["masterclass_id"])
     return render_template('signup-confirmation.html', masterclass=masterclass)
 
 
-@login_required
 @main_bp.route('/my_masterclasses', methods=['GET'])
+@login_required
 def my_masterclasses():
     user = current_user
     booked_masterclasses = user.booked_masterclasses
@@ -86,6 +86,7 @@ def choose_job_family():
         existing_masterclasses = MasterclassContent.query.filter_by(category=chosen_job_family)
         return render_template('create-masterclass/content/new-or-existing.html',  existing_masterclasses=existing_masterclasses)
 
+
 @main_bp.route('/create-masterclass/content/new-or-existing', methods=['GET', 'POST'])
 @login_required
 def choose_new_or_existing_content():
@@ -105,6 +106,7 @@ def choose_new_or_existing_content():
         return render_template('create-masterclass/content/new-or-existing.html', existing_masterclasses=existing_masterclasses)
     else:
         return Response(status_code=405) 
+
 
 @main_bp.route('/create-masterclass/content/create-new', methods=['GET', 'POST'])
 @login_required

--- a/app/routes.py
+++ b/app/routes.py
@@ -16,12 +16,12 @@ def index():
 @main_bp.route('/login', methods=['GET', 'POST'])
 def login():
     if current_user.is_authenticated:
-        return redirect(url_for('index'))
+        return redirect(url_for('main_bp.index'))
     if request.method == 'POST':
         user = User.query.filter_by(email=request.form['email-address']).first()
         if user is None or not user.check_password(request.form['password']):
             flash('Invalid username or password')
-            return redirect(url_for('login'))
+            return redirect(url_for('main_bp.login'))
         login_user(user,
                 # remember=request.form.remember_me.data
                    )
@@ -32,7 +32,7 @@ def login():
 @main_bp.route('/logout')
 def logout():
     logout_user()
-    return redirect(url_for('index'))
+    return redirect(url_for('main_bp.index'))
 
 
 @main_bp.route('/masterclass/<masterclass_id>', methods=['GET', 'POST'])

--- a/config.py
+++ b/config.py
@@ -12,9 +12,4 @@ class Config(object):
 class TestConfig(Config):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
-    LOGIN_DISABLED = True
-
-class TestLoginConfig(Config):
-    TESTING = True
-    SQLALCHEMY_DATABASE_URI = 'sqlite://'
     LOGIN_DISABLED = False

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -97,6 +97,11 @@ def test_logging_in(test_client, db, test_user):
     assert response.location == f'http://localhost{url_for("main_bp.index")}'
 
 
+def test_access_homepage_logged_in(logged_in_user, db):
+    response = logged_in_user.get('/')
+    assert response.status_code == 200
+
+
 @contextmanager
 def captured_templates(app):
     recorded = []

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -86,7 +86,6 @@ def captured_templates(app):
     recorded = []
     def record(sender, template, context, **extra):
         recorded.append((template, context))
-        print('hereeeeee', context)
     template_rendered.connect(record, app)
     try:
         yield recorded

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -97,6 +97,24 @@ def test_logging_in(test_client, db, test_user):
     assert response.location == f'http://localhost{url_for("main_bp.index")}'
 
 
+@pytest.mark.parametrize(
+    'route',
+    (
+        ('/'),
+        ('/masterclass/1'),
+        ('/signup-confirmation'),
+        ('/create-masterclass'),
+        ('/create-masterclass/content/job-family'),
+        ('/create-masterclass/content/new-or-existing'),
+        ('/create-masterclass/content/create-new')
+    )
+)
+def test_cannot_access_routes_when_not_logged_in(test_client, db, new_masterclass, route):
+    response = test_client.get(route)
+    assert response.status_code == 302
+    assert url_for("main_bp.login") in response.location
+
+
 def test_access_homepage_logged_in(logged_in_user, db):
     response = logged_in_user.get('/')
     assert response.status_code == 200

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -28,10 +28,10 @@ def test_client(test_app):
     ctx.pop()
 
 @pytest.fixture
-def logged_in_user(test_client):
+def logged_in_user(test_client, db, test_user):
     with test_client:
         test_client.post(
-            "main_bp.login", data={"email-address": "test@user.com", "password": "Password"}
+            url_for("main_bp.login"), data={"email-address": "test@user.com", "password": "password"}
         )
         yield test_client
         test_client.get("main_bp.logout")


### PR DESCRIPTION
Previous tests which checked what a user was able to access depending on if they were logged in were ineffective because:

1. on some routes the `@login_required` decorator was in the wrong position, meaning it wasn't actually working.
2. the logged_in_user fixture wasn't actually a logged in user as there were no users in the test database.

This PR fixes these two issues and also adds some additional tests around a non-logged-in user being redirected from certain routes, and a logged in user being able to access the homepage.

As a result of these improvements, I have chosen to remove the `TestLoginConfig` config class and instead pass the now working `logged_in_user` fixture to tests which require it. This means that just one `test_app` fixture is needed.