### PR TITLE
Update how location details are displayed across app

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -51,7 +51,7 @@ class Location(db.Model):
     masterclasses = db.relationship('Masterclass', backref='location', lazy='dynamic')
 
     def __repr__(self):
-        return '<Location {}>'.format(self.building)
+        return '<Location {}>'.format(self.name)
 
 
 class Masterclass(db.Model):

--- a/app/routes.py
+++ b/app/routes.py
@@ -45,7 +45,7 @@ def masterclass_profile(masterclass_id):
             db.session.add(new_attendee) 
             db.session.commit()
             return redirect(url_for('main_bp.signup_confirmation', masterclass_id=masterclass_id))
-    return render_template('masterclass-profile.html', masterclass_data=masterclass, already_attendee=already_attendee)
+    return render_template('masterclass-profile.html', masterclass=masterclass, already_attendee=already_attendee)
 
 
 @main_bp.route('/signup-confirmation', methods=['GET'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -9,7 +9,7 @@ main_bp = Blueprint("main_bp", __name__)
 @main_bp.route('/index', methods=['GET'])
 @login_required
 def index():
-    masterclasses = Masterclass.query.filter_by(draft=None).order_by(Masterclass.timestamp.asc()).all()
+    masterclasses = Masterclass.query.filter_by(draft=False).order_by(Masterclass.timestamp.asc()).all()
     return render_template('index.html', title='Home', user=User, masterclasses=masterclasses)
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -44,7 +44,7 @@ def masterclass_profile(masterclass_id):
             new_attendee = MasterclassAttendee(attendee_id = current_user.id, masterclass_id = masterclass_id) 
             db.session.add(new_attendee) 
             db.session.commit()
-            return redirect(url_for('signup_confirmation', masterclass_id=masterclass_id))
+            return redirect(url_for('main_bp.signup_confirmation', masterclass_id=masterclass_id))
     return render_template('masterclass-profile.html', masterclass_data=masterclass, already_attendee=already_attendee)
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,13 @@
             <table>
                 <tr class="govuk-table__row">
                     <td class="govuk-caption-m govuk-!-padding-right-6">Location</td>
-                    <td class="govuk-body">{{ masterclass.location.building }}, {{ masterclass.location.town_or_city }}, {{masterclass.location.postcode }}</td>
+                        <td class="govuk-body">
+                        {% if masterclass.is_remote %}
+                            Remote
+                        {% else %}
+                            {{ masterclass.location.name }}, {{ masterclass.location.address }}
+                        {% endif %}
+                        </td>                    
                 </tr>
                 <tr>
                     <td class="govuk-caption-m govuk-!-padding-right-6">Date</td>

--- a/app/templates/masterclass-profile.html
+++ b/app/templates/masterclass-profile.html
@@ -30,10 +30,17 @@
                     <h2 class="govuk-heading-m">Location</h2>
                     {% if masterclass_data.is_remote %}
                         <p class="govuk-body">Remote</p>
+                        {% if already_attendee %}
+                            <h2 class="govuk-heading-m">Joining link</h2>
+                                <p class="govuk-body"><a href={{ masterclass_data.remote_url }}>{{ masterclass_data.remote_url }}</a></p>
+                            <h2 class="govuk-heading-m">Joining instructions</h2>
+                                <p class="govuk-body">{{ masterclass_data.remote_joining_instructions }}</p>
+                        {% endif %}
                     {% else %}
                         <p class="govuk-body">{{ masterclass_data.location.name }}</p>
                         <p class="govuk-body">{{ masterclass_data.location.address }}</p>
                     {% endif %}
+                <tr>
                     <h2 class="govuk-heading-m">Instructor</h2>
                     <p class="govuk-body">{{ masterclass_data.instructor.first_name }} {{ masterclass_data.instructor.last_name }}</p>
                     <h2 class="govuk-heading-m">Remaining places</h2>

--- a/app/templates/masterclass-profile.html
+++ b/app/templates/masterclass-profile.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %} {% block content %}
 
-{% set spaces_remaining = masterclass_data.remaining_spaces() %}
+{% set spaces_remaining = masterclass.remaining_spaces() %}
 
 
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">{{ masterclass_data.content.name }}</h1>
+            <h1 class="govuk-heading-l">{{ masterclass.content.name }}</h1>
             {% if already_attendee %}
                 <div class="govuk-panel govuk-panel--confirmation">
                     <h1 class="govuk-panel__title">
@@ -21,28 +21,28 @@
                     </h1>
                 </div>
                 {% endif %}
-            <form class='govuk-form-group' action='/masterclass/{{ masterclass_data.id }}' method="post">   
+            <form class='govuk-form-group' action='/masterclass/{{ masterclass.id }}' method="post">   
                 <div>
                     <h2 class="govuk-heading-m">Description</h2>
-                    <p class="govuk-body">{{ masterclass_data.content.description }}</p>
+                    <p class="govuk-body">{{ masterclass.content.description }}</p>
                     <h2 class="govuk-heading-m">When</h2>
-                    <p class="govuk-body">{{ masterclass_data.timestamp.strftime("%X") }} <br> {{ masterclass_data.timestamp.strftime("%A") }} {{ masterclass_data.timestamp.day }} {{ masterclass_data.timestamp.strftime("%B") }} {{ masterclass_data.timestamp.year }}</p>
+                    <p class="govuk-body">{{ masterclass.timestamp.strftime("%X") }} <br> {{ masterclass.timestamp.strftime("%A") }} {{ masterclass.timestamp.day }} {{ masterclass.timestamp.strftime("%B") }} {{ masterclass.timestamp.year }}</p>
                     <h2 class="govuk-heading-m">Location</h2>
-                    {% if masterclass_data.is_remote %}
+                    {% if masterclass.is_remote %}
                         <p class="govuk-body">Remote</p>
                         {% if already_attendee %}
                             <h2 class="govuk-heading-m">Joining link</h2>
-                                <p class="govuk-body"><a href={{ masterclass_data.remote_url }}>{{ masterclass_data.remote_url }}</a></p>
+                                <p class="govuk-body"><a href={{ masterclass.remote_url }}>{{ masterclass.remote_url }}</a></p>
                             <h2 class="govuk-heading-m">Joining instructions</h2>
-                                <p class="govuk-body">{{ masterclass_data.remote_joining_instructions }}</p>
+                                <p class="govuk-body">{{ masterclass.remote_joining_instructions }}</p>
                         {% endif %}
                     {% else %}
-                        <p class="govuk-body">{{ masterclass_data.location.name }}</p>
-                        <p class="govuk-body">{{ masterclass_data.location.address }}</p>
+                        <p class="govuk-body">{{ masterclass.location.name }}</p>
+                        <p class="govuk-body">{{ masterclass.location.address }}</p>
                     {% endif %}
                 <tr>
                     <h2 class="govuk-heading-m">Instructor</h2>
-                    <p class="govuk-body">{{ masterclass_data.instructor.first_name }} {{ masterclass_data.instructor.last_name }}</p>
+                    <p class="govuk-body">{{ masterclass.instructor.first_name }} {{ masterclass.instructor.last_name }}</p>
                     <h2 class="govuk-heading-m">Remaining places</h2>
                     <p class="govuk-body">{{ spaces_remaining }}</p>
                 </div>

--- a/app/templates/masterclass-profile.html
+++ b/app/templates/masterclass-profile.html
@@ -28,8 +28,12 @@
                     <h2 class="govuk-heading-m">When</h2>
                     <p class="govuk-body">{{ masterclass_data.timestamp.strftime("%X") }} <br> {{ masterclass_data.timestamp.strftime("%A") }} {{ masterclass_data.timestamp.day }} {{ masterclass_data.timestamp.strftime("%B") }} {{ masterclass_data.timestamp.year }}</p>
                     <h2 class="govuk-heading-m">Location</h2>
-                    <p class="govuk-body">{{ masterclass_data.location.building }}</p>
-                    <p class="govuk-body">{{ masterclass_data.location.street_number }} {{ masterclass_data.location.street_name }}, {{ masterclass_data.location.town_or_city }}, {{ masterclass_data.location.postcode }}</p>
+                    {% if masterclass_data.is_remote %}
+                        <p class="govuk-body">Remote</p>
+                    {% else %}
+                        <p class="govuk-body">{{ masterclass_data.location.name }}</p>
+                        <p class="govuk-body">{{ masterclass_data.location.address }}</p>
+                    {% endif %}
                     <h2 class="govuk-heading-m">Instructor</h2>
                     <p class="govuk-body">{{ masterclass_data.instructor.first_name }} {{ masterclass_data.instructor.last_name }}</p>
                     <h2 class="govuk-heading-m">Remaining places</h2>


### PR DESCRIPTION
Due to the recent updates to the `Location` model (#13), which meant that masterclasses could either be remote or have a location, the way masterclasses are displayed in templates is no longer correct.

This PR updates the `index` and `masterclass_profile` templates to:
1) Display the location as `Remote` if `masterclass.is_remote` is True
2) Only display the joining URL and instructions if a user is an attendee of that masterclass

I took the latter decision to avoid more people than the instructor has set as `max_attendees` being able to join the masterclass. 

I have added tests for the following cases:

- Masterclass is remote
- Masterclass has a location
- Masterclass is remote and user isn't an attendee
- Masterclass is remote and user is an attendee

TODO

- Create migration for removing old fields from `Location` model now that they are no longer used in templates