### PR TITLE
Fix my masterclasses page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,6 +1,13 @@
 from flask import render_template, url_for, flash, redirect, request, Blueprint, session, Response
 from flask_login import current_user, login_user, login_required, logout_user
-from app.models import *
+
+from app.models import (
+    Masterclass,
+    MasterclassAttendee,
+    MasterclassContent,
+    User,
+    db,
+)
 
 main_bp = Blueprint("main_bp", __name__)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -66,8 +66,8 @@ def signup_confirmation():
 @login_required
 def my_masterclasses():
     user = current_user
-    booked_masterclasses = user.booked_masterclasses
-    return render_template('my-masterclasses.html')
+    booked_masterclasses = user.get_booked_masterclasses()
+    return render_template('my-masterclasses.html', booked_masterclasses=booked_masterclasses)
 
 
 @main_bp.route('/create-masterclass', methods=['GET', 'POST'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -62,7 +62,7 @@ def signup_confirmation():
     return render_template('signup-confirmation.html', masterclass=masterclass)
 
 
-@main_bp.route('/my_masterclasses', methods=['GET'])
+@main_bp.route('/my-masterclasses', methods=['GET'])
 @login_required
 def my_masterclasses():
     user = current_user

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -31,12 +31,12 @@
                         </a>
                     </li>
                     <li class="govuk-header__navigation-item">
-                        <a class="govuk-header__link" href="#2">
+                        <a class="govuk-header__link" href="/">
                             Upcoming
                         </a>
                     </li>
                     <li class="govuk-header__navigation-item">
-                        <a class="govuk-header__link" href="#3">
+                        <a class="govuk-header__link" href="{{ url_for('main_bp.my_masterclasses') }}">
                             My masterclasses
                         </a>
                     </li>
@@ -44,7 +44,7 @@
                         {% if current_user.is_anonymous %}
                         <a class="govuk-header__link" href="{{ url_for('main_bp.login') }}">
                             Login
-                        </a> 
+                        </a>
                         {% else %}
                         <a class="govuk-header__link" href="{{ url_for('main_bp.logout') }}">
                             Logout

--- a/app/templates/my-masterclasses.html
+++ b/app/templates/my-masterclasses.html
@@ -3,40 +3,43 @@
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper">
         <h1 class="govuk-heading-l">My masterclasses</h1>
+        {% if booked_masterclasses|length > 0 %}
+            {% for masterclass in booked_masterclasses %}
 
-        {% for masterclass in booked_masterclasses %}
+            <div class="app-content-panel">
+                <h2 class="govuk-heading-m"><a class="govuk-link--no-visited-state" href="{{ url_for('main_bp.masterclass_profile', masterclass_id=masterclass.id) }}">{{ masterclass.content.name }}</a></h2>
+                <table>
+                    <tr class="govuk-table__row">
+                        <td class="govuk-caption-m govuk-!-padding-right-6">Location</td>
+                            <td class="govuk-body">
+                            {% if masterclass.is_remote %}
+                                Remote
+                            {% else %}
+                                {{ masterclass.location.name }}, {{ masterclass.location.address }}
+                            {% endif %}
+                            </td>
+                    </tr>
+                    <tr>
+                        <td class="govuk-caption-m govuk-!-padding-right-6">Date</td>
+                        <td class="govuk-body">{{ masterclass.timestamp.strftime("%A") }} {{ masterclass.timestamp.day }} {{ masterclass.timestamp.strftime("%B") }} {{ masterclass.timestamp.year }}</td>
+                    </tr>
+                    <tr>
+                        <td class="govuk-caption-m govuk-!-padding-right-6">Time</td>
+                        <td class="govuk-body">{{ masterclass.timestamp.strftime("%X") }}</td>
+                    </tr>
+                    <tr>
+                        <td class="govuk-caption-m govuk-!-padding-right-6">Instructor</td>
+                        <td class="govuk-body">{{ masterclass.instructor.first_name }} {{ masterclass.instructor.last_name }}</td>
+                    </tr>
+                </table>
+            </div>
+            <hr>
 
-        <div class="app-content-panel">
-            <h2 class="govuk-heading-m"><a class="govuk-link--no-visited-state" href="{{ url_for('masterclass_profile', masterclass_id=masterclass.id) }}">{{ masterclass.content.name }}</a></h2>
-            <table>
-                <tr class="govuk-table__row">
-                    <td class="govuk-caption-m govuk-!-padding-right-6">Location</td>
-                        <td class="govuk-body">
-                        {% if masterclass.is_remote %}
-                            Remote
-                        {% else %}
-                             {{ masterclass.location.name }}, {{ masterclass.location.address }}
-                        {% endif %}
-                        </td>
-                </tr>
-                <tr>
-                    <td class="govuk-caption-m govuk-!-padding-right-6">Date</td>
-                    <td class="govuk-body">{{ masterclass.timestamp.strftime("%A") }} {{ masterclass.timestamp.day }} {{ masterclass.timestamp.strftime("%B") }} {{ masterclass.timestamp.year }}</td>
-                </tr>
-                <tr>
-                    <td class="govuk-caption-m govuk-!-padding-right-6">Time</td>
-                    <td class="govuk-body">{{ masterclass.timestamp.strftime("%X") }}</td>
-                </tr>
-                <tr>
-                    <td class="govuk-caption-m govuk-!-padding-right-6">Instructor</td>
-                    <td class="govuk-body">{{ masterclass.instructor.first_name }} {{ masterclass.instructor.last_name }}</td>
-                </tr>
-            </table>
-        </div>
-        <hr>
-
-        {% endfor %}
-
+            {% endfor %}
+        {% else %}
+            <p class="govuk-body">You haven't booked any masterclasses.</p>
+            <p class="govuk-body">You can find upcoming masterclasses <a class="govuk-link--no-visited-state" href="/">on the homepage</a>.</p>
+        {% endif %}
     </main>
 </div>
 

--- a/app/templates/my-masterclasses.html
+++ b/app/templates/my-masterclasses.html
@@ -11,7 +11,13 @@
             <table>
                 <tr class="govuk-table__row">
                     <td class="govuk-caption-m govuk-!-padding-right-6">Location</td>
-                    <td class="govuk-body">{{ masterclass.location.building }}, {{ masterclass.location.town_or_city }}, {{masterclass.location.postcode }}</td>
+                        <td class="govuk-body">
+                        {% if masterclass.is_remote %}
+                            Remote
+                        {% else %}
+                             {{ masterclass.location.name }}, {{ masterclass.location.address }}
+                        {% endif %}
+                        </td>
                 </tr>
                 <tr>
                     <td class="govuk-caption-m govuk-!-padding-right-6">Date</td>
@@ -27,7 +33,10 @@
                 </tr>
             </table>
         </div>
-        <hr> {% endfor %}
+        <hr>
+
+        {% endfor %}
+
     </main>
 </div>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+from flask import url_for
+
+from app import create_app
+from app import db as _db
+from app.models import Masterclass, User
+from config import TestConfig
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def test_app():
+    app = create_app(TestConfig)
+    yield app
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_client(test_app):
+
+    # Flask provides a way to test your application by exposing the Werkzeug test Client
+    # and handling the context locals for you.
+    testing_client = test_app.test_client()
+
+    # Establish an application context before running the tests.
+    ctx = test_app.test_request_context()
+    ctx.push()
+
+    yield testing_client  # this is where the testing happens!
+
+    ctx.pop()
+
+
+@pytest.fixture
+def logged_in_user(test_client, db, test_user):
+    with test_client:
+        test_client.post(
+            url_for("main_bp.login"),
+            data={"email-address": "test@user.com", "password": "password"}
+        )
+        yield test_client
+        test_client.get("main_bp.logout")
+
+
+@pytest.fixture(scope="session")
+def db(test_client):
+    """
+    This takes the FlaskClient object and applies it to the database.app attribute. Once this fixture is finished with, it drops everything in there
+    """
+    _db.app = test_client.application
+    _db.create_all()
+
+    yield _db
+
+    _db.drop_all()
+
+
+@pytest.fixture(scope="function", autouse=False)
+def blank_session(db):
+    connection = db.engine.connect()
+    transaction = connection.begin()
+
+    options = dict(bind=connection, binds={})
+    session_ = db.create_scoped_session(options=options)
+
+    db.session = session_
+
+    print("Yielding blank session")
+    yield session_
+
+    transaction.rollback()
+    connection.close()
+    session_.remove()
+    print("Rolled back blank session")
+
+
+@pytest.fixture
+def test_user(db, blank_session):
+    u = User(email='test@example.com')
+    u.set_password('password')
+    db.session.add(u)
+    db.session.commit()
+    yield u
+
+
+@pytest.fixture()
+def test_masterclass(db, blank_session):
+    m = Masterclass(id=1)
+    db.session.add(m)
+    db.session.commit()
+    yield m

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -8,79 +8,13 @@ from app import db as _db
 from config import *
 from app.models import MasterclassContent, Masterclass, Location, User
 
-@pytest.fixture(scope="session")
-def test_app():
-    app = create_app(TestConfig)
-    yield app
-
-@pytest.fixture(scope="session", autouse=True)
-def test_client(test_app):
-
-    # Flask provides a way to test your application by exposing the Werkzeug test Client
-    # and handling the context locals for you.
-    testing_client = test_app.test_client()
-
-    # Establish an application context before running the tests.
-    ctx = test_app.test_request_context()
-    ctx.push()
-
-    yield testing_client  # this is where the testing happens!
-
-    ctx.pop()
 
 @pytest.fixture
-def logged_in_user(test_client, db, test_user):
-    with test_client:
-        test_client.post(
-            url_for("main_bp.login"), data={"email-address": "test@user.com", "password": "password"}
-        )
-        yield test_client
-        test_client.get("main_bp.logout")
-
-@pytest.fixture(scope="session")
-def db(test_client):
-    """
-    This takes the FlaskClient object and applies it to the database.app attribute. Once this fixture is finished with, it drops everything in there
-    """
-    _db.app = test_client.application
-    _db.create_all()
-
-    yield _db
-
-    _db.drop_all()
-
-@pytest.fixture
-def test_user(db, blank_session):
-    u = User(email='test@example.com')
-    u.set_password('password')
-    db.session.add(u)
-    db.session.commit()
-    yield
-
-@pytest.fixture(scope="function", autouse=False)
-def blank_session(db):
-    connection = db.engine.connect()
-    transaction = connection.begin()
-
-    options = dict(bind=connection, binds={})
-    session_ = db.create_scoped_session(options=options)
-
-    db.session = session_
-
-    print("Yielding blank session")
-    yield session_
-
-    transaction.rollback()
-    connection.close()
-    session_.remove()
-    print("Rolled back blank session")
-
-@pytest.fixture
-def new_masterclass_content_data_category(db, blank_session):
-    mc = MasterclassContent(name='Introduction to R', description='This masterclass will give you a solid understanding of how to run queries using R.', category='Data')
+def test_content_data_category(db, blank_session):
+    mc = MasterclassContent(id=1, name='Introduction to R', description='This masterclass will give you a solid understanding of how to run queries using R.', category='Data')
     db.session.add(mc)
     db.session.commit()
-    yield 
+
 
 @pytest.fixture()
 def new_location(db, blank_session):

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -146,3 +146,12 @@ def test_remote_joining_info_visible_in_masterclass_profile_if_user_is_attendee(
     logged_in_user.post('/masterclass/2')
     response = logged_in_user.get('/masterclass/2')
     assert '<h2 class="govuk-heading-m">Joining link</h2>' in response.get_data(as_text=True)
+
+def test_display_my_masterclasses_with_none_booked(logged_in_user, blank_session):
+    response = logged_in_user.get('/my-masterclasses')
+    assert '<p class="govuk-body">You haven\'t booked any masterclasses.</p>' in response.get_data(as_text=True)
+
+def test_display_my_masterclasses(logged_in_user, test_masterclass_with_details, test_content_data_category, blank_session):
+    logged_in_user.post(f'/masterclass/{test_masterclass_with_details.id}')
+    response = logged_in_user.get('/my-masterclasses')
+    assert f'<a class="govuk-link--no-visited-state" href="/masterclass/1">{test_masterclass_with_details.content.name}</a>' in response.get_data(as_text=True)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,27 @@
+from app.models import MasterclassAttendee, User
+
+import pytest
+
+# Re-write as unit tests
+# Start with adding new objects from scratch instead of starting with factories
+
+
+def test_get_booked_masterclasses_when_not_signed_up():
+    """Test empty list is returned if a user has no booked masterclasses."""
+    user = User()
+    assert user.get_booked_masterclasses() == []
+
+
+def test_get_booked_masterclasses(
+    db,
+    blank_session,
+    test_masterclass,
+    test_user,
+):
+    """Test list of masterclass objects returned if user has any booked."""
+    ma = MasterclassAttendee(
+      attendee_id=test_user.id,
+      masterclass_id=test_masterclass.id)
+    db.session.add(ma)
+    db.session.commit()
+    assert test_user.get_booked_masterclasses() == [test_masterclass]


### PR DESCRIPTION
This PR makes fixes to the `My Masterclasses` functionality which was previously not working, due to the variable `booked_masterclasses` being passed to the template as instances of `MasterclassAttendee` rather than `Masterclass`.

To rectify this issue I have created a method on the User model which will return a list of the Masterclass objects a user has booked. I have also updated the display of masterclasses in the `my-masterclasses` template to reflect there now being remote or 'location' masterclasses and updated the route to be `my-masterclasses` instead of `my_masterclasses`, in-line with other routes on the app.

This PR also includes updates to tests which came from the creation of a unit tests file. These include:

- Moving common fixtures out into a `conftest` file so that they are accessible by multiple test files
- For database fixtures, yielding the database object so that tests can instantly use this object instead of having to get the object out of the database again
- Renaming all database fixtures to be prefixed with `test` for clarity and consistency