### PR TITLE
Add a location to a masterclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 app.db
 *.pyc
 /venv
+.flaskenv

--- a/.sample_flaskenv
+++ b/.sample_flaskenv
@@ -1,0 +1,2 @@
+FLASK_APP=masterclasses.py
+GOOGLE_MAPS_API_KEY=YOUR_KEY_HERE

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,11 +3,14 @@ from config import Config
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_login import LoginManager
+import googlemaps
+import os
 
 db = SQLAlchemy()
 migrate = Migrate()
 login = LoginManager()
 login.login_view = 'main_bp.login'
+gmaps = googlemaps.Client(key=os.environ.get("GOOGLE_MAPS_API_KEY", default='AIza_KEY_HERE'))
 
 
 def create_app(config_class=Config):

--- a/app/models.py
+++ b/app/models.py
@@ -88,8 +88,31 @@ class Masterclass(db.Model):
     def remaining_spaces(self):
         return self.max_attendees - len(self.attendees)
 
-    def update_remote_status(self, is_remote: bool):
-        self.is_remote = is_remote
+    def set_location_details(self, data, is_remote):
+        """
+        Set location related fields for a masterclass.
+        """
+        if is_remote:
+            self.set_remote_details(data)
+        else:
+            self.set_in_person_details(data)
+        db.session.add(self)
+        db.session.commit()
+        return None
+
+    def set_remote_details(self, data):
+        self.remote_url = data["url"]
+        if data["joining_instructions"]:
+            self.remote_joining_instructions = data["joining_instructions"]
+        self.is_remote = True
+        return None
+
+    def set_in_person_details(self, data):
+        self.room = data["room"]
+        self.floor = data["floor"]
+        if data["building_instructions"]:
+            self.building_instructions = data["building_instructions"]
+        self.is_remote = False
         return None
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import UserMixin
 from typing import List, Union
 from sqlalchemy import or_
+from sqlalchemy_serializer import SerializerMixin
 
 
 class User(UserMixin, db.Model):   # User inherits from db.Model, a base class for all models from Flask-sqlalchemy
@@ -47,7 +48,7 @@ class MasterclassContent(db.Model):
         return '<MasterclassContent {}>'.format(self.name)
 
 
-class Location(db.Model):
+class Location(db.Model, SerializerMixin):
     id = db.Column(db.Integer, primary_key=True)
     building = db.Column(db.String(50), index=True)
     street_number = db.Column(db.String(10)) # should keep numbers as strings unless going to do calculations?

--- a/app/models.py
+++ b/app/models.py
@@ -86,7 +86,11 @@ class Masterclass(db.Model):
 
     def remaining_spaces(self):
         return self.max_attendees - len(self.attendees)
-        
+
+    def update_remote_status(self, is_remote: bool):
+        self.is_remote = is_remote
+        return None
+
 
 class MasterclassAttendee(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/routes.py
+++ b/app/routes.py
@@ -170,16 +170,14 @@ def add_online_details():
             return render_template(
                 "create-masterclass/location/online-details.html",
                 validation_error=True,
-                joining_instructions=request.form.get("joining_instructions")
+                joining_instructions=request.form.get("joining_instructions"),
             ), 403
-        draft_masterclass = Masterclass.query.get(session["draft_masterclass_id"])
-        draft_masterclass.update_remote_status(True)
-        draft_masterclass.remote_url = request.form["url"]
-        draft_masterclass.remote_joining_instructions = request.form[
-            "joining_instructions"
-        ]
-        db.session.add(draft_masterclass)
-        db.session.commit()
+        draft_masterclass = Masterclass.query.get(
+            session["draft_masterclass_id"]
+        )
+        draft_masterclass.set_location_details(
+            data=request.form, is_remote=True,
+        )
         return redirect(url_for("main_bp.index"))
 
     return render_template("create-masterclass/location/online-details.html")
@@ -268,11 +266,6 @@ def add_in_person_location_details():
                 form_data=request.form
             ), 403
         draft_masterclass = Masterclass.query.get(session["draft_masterclass_id"])
-        draft_masterclass.room = request.form["room"]
-        draft_masterclass.floor = request.form["floor"]
-        draft_masterclass.building_instructions = request.form["building_instructions"]
-        draft_masterclass.update_remote_status(False)
-        db.session.add(draft_masterclass)
-        db.session.commit()
+        draft_masterclass.set_location_details(data=request.form, is_remote=False)
         return redirect(url_for("main_bp.index"))
     return render_template("create-masterclass/location/in-person-details.html")

--- a/app/routes.py
+++ b/app/routes.py
@@ -145,9 +145,20 @@ def choose_location_type():
         )
 
 
-@main_bp.route("/create-masterclass/location/online", methods=["GET"])
+@main_bp.route("/create-masterclass/location/online", methods=["GET", "POST"])
 @login_required
 def add_online_details():
+    if request.method == "POST":
+        draft_masterclass = Masterclass.query.get(session["draft_masterclass_id"])
+        draft_masterclass.update_remote_status(True)
+        draft_masterclass.remote_url = request.form["url"]
+        draft_masterclass.remote_joining_instructions = request.form[
+            "joining_instructions"
+        ]
+        db.session.add(draft_masterclass)
+        db.session.commit()
+        return redirect(url_for("main_bp.index"))
+
     return render_template("create-masterclass/location/online-details.html")
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -129,3 +129,29 @@ def create_new_content():
             return redirect(url_for('main_bp.index')) # TODO will take them back to task list page
     else:
         return render_template('create-masterclass/content/create-new.html')
+
+
+@main_bp.route("/create-masterclass/location/type", methods=["GET", "POST"])
+@login_required
+def choose_location_type():
+    if request.method == "POST":
+        if request.form["location-type"] == "online":
+            return redirect(url_for("main_bp.add_online_details"))
+        elif request.form["location-type"] == "in person":
+            return redirect(url_for("main_bp.search_for_location"))
+    else:
+        return render_template(
+            "create-masterclass/location/choose-location-type.html"
+        )
+
+
+@main_bp.route("/create-masterclass/location/online", methods=["GET"])
+@login_required
+def add_online_details():
+    return render_template("create-masterclass/location/online-details.html")
+
+
+@main_bp.route("/create-masterclass/location/search", methods=["GET"])
+@login_required
+def search_for_location():
+    return render_template("create-masterclass/location/search.html")

--- a/app/routes.py
+++ b/app/routes.py
@@ -147,6 +147,11 @@ def create_new_content():
 @login_required
 def choose_location_type():
     if request.method == "POST":
+        if not request.form.get("location-type"):
+            return render_template(
+                "create-masterclass/location/choose-location-type.html",
+                validation_error=True
+            ), 403
         if request.form["location-type"] == "online":
             return redirect(url_for("main_bp.add_online_details"))
         elif request.form["location-type"] == "in person":
@@ -161,6 +166,12 @@ def choose_location_type():
 @login_required
 def add_online_details():
     if request.method == "POST":
+        if not request.form.get("url"):
+            return render_template(
+                "create-masterclass/location/online-details.html",
+                validation_error=True,
+                joining_instructions=request.form.get("joining_instructions")
+            ), 403
         draft_masterclass = Masterclass.query.get(session["draft_masterclass_id"])
         draft_masterclass.update_remote_status(True)
         draft_masterclass.remote_url = request.form["url"]
@@ -178,6 +189,11 @@ def add_online_details():
 @login_required
 def search_for_location():
     if request.method == "POST":
+        if not request.form.get("location"):
+            return render_template(
+                "create-masterclass/location/search.html",
+                validation_error=True
+            ), 403
         query = request.form["location"]
         results = Location.return_existing_location_or_none(query)[0:3]
         if results:
@@ -201,6 +217,13 @@ def location_search_results():
     results = session["location_search_results"]
     is_database_data = session["location_in_db"]
     if request.method == "POST":
+        if not request.form.get("select-location"):
+            return render_template(
+                "create-masterclass/location/search-results.html",
+                validation_error=True,
+                results=results,
+                is_database_data=is_database_data,
+            ), 403
         draft_masterclass = Masterclass.query.get(session["draft_masterclass_id"])
         location = results[int(request.form["select-location"])]
         if is_database_data:
@@ -231,6 +254,19 @@ def location_search_results():
 @login_required
 def add_in_person_location_details():
     if request.method == "POST":
+        mandatory_fields = ["room", "floor"]
+        filled_fields = [
+            field for field in mandatory_fields if request.form[field] != ''
+        ]
+        if not all(field in filled_fields for field in mandatory_fields):
+            return render_template(
+                "create-masterclass/location/in-person-details.html",
+                validation_error=True,
+                empty_fields=[
+                    field for field in mandatory_fields if field not in filled_fields
+                ],
+                form_data=request.form
+            ), 403
         draft_masterclass = Masterclass.query.get(session["draft_masterclass_id"])
         draft_masterclass.room = request.form["room"]
         draft_masterclass.floor = request.form["floor"]

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,14 @@
-from flask import render_template, url_for, flash, redirect, request, Blueprint, session, Response
+from flask import (
+    Blueprint,
+    flash,
+    redirect,
+    render_template,
+    request,
+    Response,
+    session,
+    url_for,
+)
+
 from flask_login import current_user, login_user, login_required, logout_user
 
 from app.models import (
@@ -217,7 +227,16 @@ def location_search_results():
     )
 
 
-@main_bp.route("/create-masterclass/location/details", methods=["GET"])
+@main_bp.route("/create-masterclass/location/details", methods=["GET", "POST"])
 @login_required
 def add_in_person_location_details():
+    if request.method == "POST":
+        draft_masterclass = Masterclass.query.get(session["draft_masterclass_id"])
+        draft_masterclass.room = request.form["room"]
+        draft_masterclass.floor = request.form["floor"]
+        draft_masterclass.building_instructions = request.form["building_instructions"]
+        draft_masterclass.update_remote_status(False)
+        db.session.add(draft_masterclass)
+        db.session.commit()
+        return redirect(url_for("main_bp.index"))
     return render_template("create-masterclass/location/in-person-details.html")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,15 +11,11 @@
 <header class="govuk-header " role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
-            <a href="#" class="govuk-header__link govuk-header__link--homepage">
                 <span class="govuk-header__logotype">
-                    <a href="{{ url_for('main_bp.index') }}" class='govuk-header__link'>
-                      <span class="govuk-header__logotype-text">
+                    <a href="{{ url_for('main_bp.index') }}" class='govuk-header__link govuk-header__link--service-name' style="margin-bottom: 0px;">
                       Masterclasses 
-                      </span>
                     </a>
                 </span>
-            </a>
         </div>
         <div align="right" class="govuk-header__content">
             <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>

--- a/app/templates/create-masterclass/location/choose-location-type.html
+++ b/app/templates/create-masterclass/location/choose-location-type.html
@@ -1,33 +1,52 @@
 {% set back_url=url_for("main_bp.index") %}
 {% extends "form-page-base.html" %}
 {% block main_content %}
-  <form action="/create-masterclass/location/type" method="post" novalidate>
-
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            Will your masterclass be online or in person?
-          </h1>
-        </legend>
-        <div class="govuk-radios">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="online" name="location-type" type="radio" value="online">
-            <label class="govuk-label govuk-radios__label" for="online">
-              Online
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="in-person" name="location-type" type="radio" value="in person">
-            <label class="govuk-label govuk-radios__label" for="in-person">
-              In person
-            </label>
-          </div>
-        </div>
-        </br>
-        <button class="govuk-button" data-module="govuk-button">
-          Continue
-        </button>
+<form action="/create-masterclass/location/type" method="post">
+  {% if validation_error %}
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+    data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#online">Select a location type for your masterclass</a>
+        </li>
+      </ul>
     </div>
-  </form>
+  </div>
+  {% endif %}
+  <div class="govuk-form-group {% if validation_error %}govuk-form-group--error{% endif %}">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+          Will your masterclass be online or in person?
+        </h1>
+      </legend>
+      {% if validation_error %}
+      <span id="masterclass-type-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span> Select a location type for your masterclass
+      </span>
+      {% endif %}
+      <div class="govuk-radios">
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="online" name="location-type" type="radio" value="online">
+          <label class="govuk-label govuk-radios__label" for="online">
+            Online
+          </label>
+        </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="in-person" name="location-type" type="radio" value="in person">
+          <label class="govuk-label govuk-radios__label" for="in-person">
+            In person
+          </label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+  <button class="govuk-button" data-module="govuk-button">
+    Continue
+  </button>
+</form>
 {% endblock %}

--- a/app/templates/create-masterclass/location/choose-location-type.html
+++ b/app/templates/create-masterclass/location/choose-location-type.html
@@ -1,0 +1,33 @@
+{% set back_url=url_for("main_bp.index") %}
+{% extends "form-page-base.html" %}
+{% block main_content %}
+  <form action="/create-masterclass/location/type" method="post" novalidate>
+
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            Will your masterclass be online or in person?
+          </h1>
+        </legend>
+        <div class="govuk-radios">
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="online" name="location-type" type="radio" value="online">
+            <label class="govuk-label govuk-radios__label" for="online">
+              Online
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="in-person" name="location-type" type="radio" value="in person">
+            <label class="govuk-label govuk-radios__label" for="in-person">
+              In person
+            </label>
+          </div>
+        </div>
+        </br>
+        <button class="govuk-button" data-module="govuk-button">
+          Continue
+        </button>
+    </div>
+  </form>
+{% endblock %}

--- a/app/templates/create-masterclass/location/in-person-details.html
+++ b/app/templates/create-masterclass/location/in-person-details.html
@@ -1,0 +1,39 @@
+{% set back_url=url_for("main_bp.location_search_results") %}
+{% extends "form-page-base.html" %}
+{% block main_content %}
+  <form action="/create-masterclass/location/details" method="POST" novalidate>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            Location details
+          </h1>
+        </legend>
+        </br>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="room">
+              Room number
+          </label>
+          <input class="govuk-input govuk-input--width-10" id="room" name="room" type="text">
+        </div>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="floor">
+              Floor
+          </label>
+          <input class="govuk-input govuk-input--width-10" id="floor" name="floor" type="text">
+        </div>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="building_instructions">
+              Instructions for entering the building
+          </label>
+          <span id="more-detail-hint" class="govuk-hint">
+              What do people know to know in order to enter the building, for example can they enter with a cross-government pass?
+          </span>
+          <textarea class="govuk-textarea" id="building_instructions" name="building_instructions" rows="5"></textarea>
+        </div>
+    </div>
+    <button class="govuk-button" data-module="govuk-button">
+      Continue
+    </button>
+  </form>
+{% endblock %}

--- a/app/templates/create-masterclass/location/in-person-details.html
+++ b/app/templates/create-masterclass/location/in-person-details.html
@@ -1,39 +1,74 @@
 {% set back_url=url_for("main_bp.location_search_results") %}
 {% extends "form-page-base.html" %}
 {% block main_content %}
-  <form action="/create-masterclass/location/details" method="POST" novalidate>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            Location details
-          </h1>
-        </legend>
-        </br>
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="room">
-              Room number
-          </label>
-          <input class="govuk-input govuk-input--width-10" id="room" name="room" type="text">
-        </div>
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="floor">
-              Floor
-          </label>
-          <input class="govuk-input govuk-input--width-10" id="floor" name="floor" type="text">
-        </div>
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="building_instructions">
-              Instructions for entering the building
-          </label>
-          <span id="more-detail-hint" class="govuk-hint">
-              What do people know to know in order to enter the building, for example can they enter with a cross-government pass?
-          </span>
-          <textarea class="govuk-textarea" id="building_instructions" name="building_instructions" rows="5"></textarea>
-        </div>
+<form action="/create-masterclass/location/details" method="POST" novalidate>
+  {% if validation_error %}
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+    data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        {% if "room" in empty_fields%}
+        <li>
+          <a href="#room">Enter a room name or number for your masterclass</a>
+        </li>
+        {% endif %}
+        {% if "floor" in empty_fields%}
+        <li>
+          <a href="#floor">Enter a floor for your masterclass</a>
+        </li>
+        {% endif %}
+      </ul>
     </div>
-    <button class="govuk-button" data-module="govuk-button">
-      Continue
-    </button>
-  </form>
+  </div>
+  {% endif %}
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading">
+        Location details
+      </h1>
+    </legend>
+    </br>
+    <div class="govuk-form-group {% if 'room' in empty_fields %}govuk-form-group--error{% endif %}">
+      <label class="govuk-label" for="room">
+        Room name or number
+      </label>
+      {% if "room" in empty_fields%}
+      <span id="masterclass-type-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span>Enter a room name or number for your masterclass
+      </span>
+      {% endif %}
+      <input class="govuk-input govuk-input--width-10" id="room" name="room" type="text"
+        value="{% if validation_error %}{{ form_data['room'] }}{% endif %}">
+    </div>
+    <div class="govuk-form-group {% if 'floor' in empty_fields %}govuk-form-group--error{% endif %}">
+      <label class="govuk-label" for="floor">
+        Floor
+      </label>
+      {% if "floor" in empty_fields%}
+      <span id="masterclass-type-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span>Enter a floor for your masterclass
+      </span>
+      {% endif %}
+      <input class="govuk-input govuk-input--width-10" id="floor" name="floor" type="text"
+        value="{% if validation_error %}{{ form_data['floor'] }}{% endif %}">
+    </div>
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="building_instructions">
+        Instructions for entering the building (optional)
+      </label>
+      <span id="more-detail-hint" class="govuk-hint">
+        What do people know to know in order to enter the building, for example can they enter with a cross-government
+        pass?
+      </span>
+      <textarea class="govuk-textarea" id="building_instructions" name="building_instructions"
+        rows="5">{% if validation_error %}{{ form_data['building_instructions'] }}{% endif %}</textarea>
+    </div>
+  </fieldset>
+  <button class="govuk-button" data-module="govuk-button">
+    Continue
+  </button>
+</form>
 {% endblock %}

--- a/app/templates/create-masterclass/location/online-details.html
+++ b/app/templates/create-masterclass/location/online-details.html
@@ -1,31 +1,48 @@
 {% set back_url=url_for("main_bp.choose_location_type") %}
 {% extends "form-page-base.html" %}
 {% block main_content %}
-  <form action="/create-masterclass/location/online" method="post" novalidate>
-
+<form action="/create-masterclass/location/online" method="post">
+  {% if validation_error %}
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+    data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#url">Enter a url to join your masterclass online</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading">
+        Joining instructions for your online masterclass
+      </h1>
+    </legend>
+    <div class="govuk-form-group {% if validation_error %}govuk-form-group--error{% endif %}">
+      <label class="govuk-label" for="url">
+        Url to join online
+      </label>
+      {% if validation_error %}
+      <span id="masterclass-type-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span>Enter a url to join your masterclass online
+      </span>
+      {% endif %}
+      <input class="govuk-input {% if validation_error %}govuk-input--error{% endif %}" id="url" name="url" type="text">
+    </div>
     <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            Joining instructions for your online masterclass
-          </h1>
-        </legend>
-        </br>
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="url">
-              Url to join online
-          </label>
-          <input class="govuk-input" id="url" name="url" type="text">
-        </div>
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="joining_instructions">
-              Joining instructions
-          </label>
-          <textarea class="govuk-textarea" id="joining_instructions" name="joining_instructions" rows="5"></textarea>
-        </div>
+      <label class="govuk-label" for="joining_instructions">
+        Joining instructions (optional)
+      </label>
+      <textarea class="govuk-textarea" id="joining_instructions" name="joining_instructions"
+        rows="5">{{ joining_instructions }}</textarea>
     </div>
     <button class="govuk-button" data-module="govuk-button">
       Continue
     </button>
-  </form>
+</form>
 {% endblock %}

--- a/app/templates/create-masterclass/location/online-details.html
+++ b/app/templates/create-masterclass/location/online-details.html
@@ -1,0 +1,31 @@
+{% set back_url=url_for("main_bp.choose_location_type") %}
+{% extends "form-page-base.html" %}
+{% block main_content %}
+  <form action="/create-masterclass/location/online" method="post" novalidate>
+
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            Joining instructions for your online masterclass
+          </h1>
+        </legend>
+        </br>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="url">
+              Url to join online
+          </label>
+          <input class="govuk-input" id="url" name="url" type="text">
+        </div>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="joining_instructions">
+              Joining instructions
+          </label>
+          <textarea class="govuk-textarea" id="joining_instructions" name="joining_instructions" rows="5"></textarea>
+        </div>
+    </div>
+    <button class="govuk-button" data-module="govuk-button">
+      Continue
+    </button>
+  </form>
+{% endblock %}

--- a/app/templates/create-masterclass/location/search-results.html
+++ b/app/templates/create-masterclass/location/search-results.html
@@ -1,39 +1,62 @@
 {% set back_url=url_for("main_bp.search_for_location")  %}
 {% extends "form-page-base.html" %}
 {% block main_content %}
-  <div class="govuk-form-group">
-    <form action="/create-masterclass/location/search/results" method="post" novalidate>
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              Choose a location
-            </h1>
-          </legend>
-          <span id="choose-masterclass-hint" class="govuk-hint">
-            If the location you're looking for isn't displayed, go back to the previous page and try a more specific search term.
-          </span>
-          </br>
-          <h1 class="govuk-fieldset__heading"></h1>
-          <div class="govuk-radios">
-            {% for result in results %}
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="location-{{result.name}}" name="select-location" type="radio" value={{ results.index(result) }}>
-                <label class="govuk-label govuk-radios__label" for="select-location">
-                  <strong>{{ result.name }}</strong> </br>
-                  {% if is_database_data %}
-                  {{ result.address}}
-                  {% else %}
-                  {{ result.formatted_address }}
-                  {% endif %}
-                </label>
-              </div>
-            {% endfor %}
+<div class="govuk-form-group">
+  <form action="/create-masterclass/location/search/results" method="post" novalidate>
+    {% if validation_error %}
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+      data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>
+            <a href="#location-1">Select a location</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    {% endif %}
+    <div class="govuk-form-group {% if validation_error %}govuk-form-group--error{% endif %}">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            Choose a location
+          </h1>
+        </legend>
+        <span id="choose-masterclass-hint" class="govuk-hint">
+          If the location you're looking for isn't displayed, go back to the previous page and try a more specific
+          search term.
+        </span>
+        <h1 class="govuk-fieldset__heading"></h1>
+        {% if validation_error %}
+        <span id="masterclass-type-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> Select a location
+        </span>
+        {% endif %}
+        <div class="govuk-radios">
+          {% for result in results %}
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="location-{{results.index(result)+1}}" name="select-location"
+              type="radio" value={{ results.index(result) }}>
+            <label class="govuk-label govuk-radios__label" for="select-location">
+              <strong>{{ result.name }}</strong> </br>
+              {% if is_database_data %}
+              {{ result.address}}
+              {% else %}
+              {{ result.formatted_address }}
+              {% endif %}
+            </label>
           </div>
-        </fieldset>
-        </br>
-        <button class="govuk-button" data-module="govuk-button">
-          Continue
-        </button>
-    </form>
-  </div>
+          {% endfor %}
+        </div>
+      </fieldset>
+    </div>
+    </br>
+    <button class="govuk-button" data-module="govuk-button">
+      Continue
+    </button>
+  </form>
+</div>
 {% endblock %}

--- a/app/templates/create-masterclass/location/search-results.html
+++ b/app/templates/create-masterclass/location/search-results.html
@@ -1,0 +1,39 @@
+{% set back_url=url_for("main_bp.search_for_location")  %}
+{% extends "form-page-base.html" %}
+{% block main_content %}
+  <div class="govuk-form-group">
+    <form action="/create-masterclass/location/search/results" method="post" novalidate>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              Choose a location
+            </h1>
+          </legend>
+          <span id="choose-masterclass-hint" class="govuk-hint">
+            If the location you're looking for isn't displayed, go back to the previous page and try a more specific search term.
+          </span>
+          </br>
+          <h1 class="govuk-fieldset__heading"></h1>
+          <div class="govuk-radios">
+            {% for result in results %}
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="location-{{result.name}}" name="select-location" type="radio" value={{ results.index(result) }}>
+                <label class="govuk-label govuk-radios__label" for="select-location">
+                  <strong>{{ result.name }}</strong> </br>
+                  {% if is_database_data %}
+                  {{ result.address}}
+                  {% else %}
+                  {{ result.formatted_address }}
+                  {% endif %}
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+        </fieldset>
+        </br>
+        <button class="govuk-button" data-module="govuk-button">
+          Continue
+        </button>
+    </form>
+  </div>
+{% endblock %}

--- a/app/templates/create-masterclass/location/search.html
+++ b/app/templates/create-masterclass/location/search.html
@@ -1,0 +1,25 @@
+{% set back_url=url_for("main_bp.choose_location_type") %}
+{% extends "form-page-base.html" %}
+{% block main_content %}
+  <form action="/create-masterclass/location/search" method="post" novalidate>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            Where will your masterclass take place?
+          </h1>
+        </legend>
+        </br>
+        <div class="govuk-form-group">
+          <span id="more-detail-hint" class="govuk-hint">
+              Search for an address, postcode or building name
+          </span>
+          <input class="govuk-input" id="location" name="location" type="text">
+        </div>
+      </fieldset>
+    </div>
+    <button class="govuk-button" data-module="govuk-button">
+      Search
+    </button>
+  </form>
+{% endblock %}

--- a/app/templates/create-masterclass/location/search.html
+++ b/app/templates/create-masterclass/location/search.html
@@ -1,25 +1,44 @@
 {% set back_url=url_for("main_bp.choose_location_type") %}
 {% extends "form-page-base.html" %}
 {% block main_content %}
-  <form action="/create-masterclass/location/search" method="post" novalidate>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            Where will your masterclass take place?
-          </h1>
-        </legend>
-        </br>
-        <div class="govuk-form-group">
-          <span id="more-detail-hint" class="govuk-hint">
-              Search for an address, postcode or building name
-          </span>
-          <input class="govuk-input" id="location" name="location" type="text">
-        </div>
-      </fieldset>
+<form action="/create-masterclass/location/search" method="post" novalidate>
+  {% if validation_error %}
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+    data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#location">Enter an address, postcode or building name to search for</a>
+        </li>
+      </ul>
     </div>
-    <button class="govuk-button" data-module="govuk-button">
-      Search
-    </button>
-  </form>
+  </div>
+  {% endif %}
+  <div class="govuk-form-group {% if validation_error %}govuk-form-group--error{% endif %}">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+          Where will your masterclass take place?
+        </h1>
+      </legend>
+      </br>
+      <span id="more-detail-hint" class="govuk-hint">
+        Search for an address, postcode or building name
+      </span>
+      {% if validation_error %}
+      <span id="masterclass-type-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span>Enter an address, postcode or building name to search for
+      </span>
+      {% endif %}
+      <input class="govuk-input {% if validation_error %}govuk-input--error{% endif %}" id="location" name="location"
+        type="text">
+    </fieldset>
+  </div>
+  <button class="govuk-button" data-module="govuk-button">
+    Search
+  </button>
+</form>
 {% endblock %}

--- a/app/templates/form-page-base.html
+++ b/app/templates/form-page-base.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="govuk-width-container">
+    <a href={{ back_url }} class="govuk-back-link">Back</a>
+    <main class="govuk-main-wrapper " id="main-content" role="main">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                {% block main_content %} {% endblock %}
+            </div>
+        </div>
+    </main>
+</div>
+{% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - FLASK_APP=masterclasses.py
       - SECRET_KEY=secret-dev-key
       - ENV=dev
+    env_file: .flaskenv
     ports:
       - "5000:5000"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ python-dotenv==0.10.3
 python-editor==1.0.4
 six==1.12.0
 SQLAlchemy==1.3.8
+SQLAlchemy-serializer==1.3.4.4
 wcwidth==0.1.8
 Werkzeug==0.15.5
 zipp==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Flask==1.1.1
 Flask-Login==0.4.1
 Flask-Migrate==2.5.2
 Flask-SQLAlchemy==2.4.0
+googlemaps==4.4.1
 importlib-metadata==1.5.0
 itsdangerous==1.1.0
 Jinja2==2.10.1

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -172,3 +172,15 @@ def test_redirect_to_correct_template_after_choose_location_type(
     assert response.status_code == 302
     assert response.location == f'http://localhost{url_for(f"main_bp.{redirect_url}")}'
 
+
+def test_add_online_details(logged_in_user, test_masterclass, blank_session):
+    with logged_in_user.session_transaction() as session:
+        session["draft_masterclass_id"] = 1
+    response = logged_in_user.post(
+        "/create-masterclass/location/online",
+        data={"url": "testing.com", "joining_instructions": "Please join"},
+    )
+    assert response.status_code == 302
+    assert test_masterclass.is_remote == True
+    assert test_masterclass.remote_url == "testing.com"
+    assert test_masterclass.remote_joining_instructions == "Please join"

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -184,3 +184,33 @@ def test_add_online_details(logged_in_user, test_masterclass, blank_session):
     assert test_masterclass.is_remote == True
     assert test_masterclass.remote_url == "testing.com"
     assert test_masterclass.remote_joining_instructions == "Please join"
+
+
+@pytest.mark.parametrize(
+    "query_string",
+    (("TEST BUILDING"), ("test"), ("bUiLdInG"), ("SW1"), ("sw1 1re"), ("1re")),
+)
+def test_get_existing_location_from_db_by_query_string_success(
+    logged_in_user, blank_session, test_location, query_string
+):
+    assert (
+        Location.return_existing_location_or_none(query_string)[0].name
+        == "Test building"
+    )
+
+
+def test_get_existing_location_from_db_by_query_string_failure(
+    logged_in_user, blank_session
+):
+    assert Location.return_existing_location_or_none("Nice skyscraper") == []
+
+
+def test_location_search_results_appear_on_page(
+    logged_in_user, blank_session, test_location
+):
+    response = logged_in_user.post(
+        "/create-masterclass/location/search",
+        data={"location": "test building"},
+        follow_redirects=True,
+    )
+    assert "Test building" in response.get_data(as_text=True)

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -214,3 +214,19 @@ def test_location_search_results_appear_on_page(
         follow_redirects=True,
     )
     assert "Test building" in response.get_data(as_text=True)
+
+
+def test_new_location_added_to_db(logged_in_user, test_masterclass, blank_session):
+    places_api_results = [
+        {"place_id": "123", "name": "A place", "formatted_address": "An address"}
+    ]
+    with logged_in_user.session_transaction() as session:
+        session["draft_masterclass_id"] = 1
+        session["location_search_results"] = places_api_results
+        session["location_in_db"] = False
+    response = logged_in_user.post(
+        "/create-masterclass/location/search/results", data={"select-location": "0"}
+    )
+    new_location = Location.query.filter_by(maps_id="123").first()
+    assert response.status_code == 302
+    assert test_masterclass.location_id == new_location.id

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -3,10 +3,8 @@ import pytest
 from flask import session, template_rendered, url_for
 from contextlib import contextmanager
 from datetime import datetime
-from app import create_app
-from app import db as _db
-from config import *
-from app.models import MasterclassContent, Masterclass, Location, User
+
+from app.models import Location, Masterclass, MasterclassContent
 
 
 @pytest.fixture
@@ -230,3 +228,17 @@ def test_new_location_added_to_db(logged_in_user, test_masterclass, blank_sessio
     new_location = Location.query.filter_by(maps_id="123").first()
     assert response.status_code == 302
     assert test_masterclass.location_id == new_location.id
+
+
+def test_add_in_person_details(logged_in_user, test_masterclass, blank_session):
+    with logged_in_user.session_transaction() as session:
+        session["draft_masterclass_id"] = 1
+    response = logged_in_user.post(
+        "/create-masterclass/location/details",
+        data={"room": "1D", "floor": "1", "building_instructions": "Some instructions"},
+    )
+    assert response.status_code == 302
+    assert test_masterclass.room == "1D"
+    assert test_masterclass.floor == "1"
+    assert test_masterclass.building_instructions == "Some instructions"
+    assert test_masterclass.is_remote == False

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -18,7 +18,7 @@ def test_content_data_category(db, blank_session):
 
 @pytest.fixture()
 def test_location(db, blank_session):
-    test_location = Location(id=1, name='Test building')
+    test_location = Location(id=1, name='Test building', address='1 Road, SW1 1RE')
     db.session.add(test_location)
     db.session.commit()
     yield test_location

--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -155,3 +155,20 @@ def test_display_my_masterclasses(logged_in_user, test_masterclass_with_details,
     logged_in_user.post(f'/masterclass/{test_masterclass_with_details.id}')
     response = logged_in_user.get('/my-masterclasses')
     assert f'<a class="govuk-link--no-visited-state" href="/masterclass/1">{test_masterclass_with_details.content.name}</a>' in response.get_data(as_text=True)
+
+# Add location tests
+
+
+@pytest.mark.parametrize(
+    "location_type, redirect_url",
+    (("online", "add_online_details"), ("in person", "search_for_location"),),
+)
+def test_redirect_to_correct_template_after_choose_location_type(
+    logged_in_user, location_type, redirect_url
+):
+    response = logged_in_user.post(
+        "/create-masterclass/location/type", data={"location-type": location_type}
+    )
+    assert response.status_code == 302
+    assert response.location == f'http://localhost{url_for(f"main_bp.{redirect_url}")}'
+

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,4 +1,4 @@
-from app.models import MasterclassAttendee, User
+from app.models import Masterclass, MasterclassAttendee, User
 
 import pytest
 
@@ -17,8 +17,35 @@ def test_get_booked_masterclasses(
 ):
     """Test list of masterclass objects returned if user has any booked."""
     ma = MasterclassAttendee(
-      attendee_id=test_user.id,
-      masterclass_id=test_masterclass.id)
+        attendee_id=test_user.id, masterclass_id=test_masterclass.id
+    )
     db.session.add(ma)
     db.session.commit()
     assert test_user.get_booked_masterclasses() == [test_masterclass]
+
+
+@pytest.mark.parametrize(
+    "method, data, optional_field",
+    (
+        (
+            "set_remote_details",
+            {"url": "url.com", "joining_instructions": ""},
+            "remote_joining_instructions",
+        ),
+        (
+            "set_in_person_details",
+            {"room": "1d", "floor": "1", "building_instructions": ""},
+            "building_instructions",
+        ),
+    ),
+)
+def test_empty_optional_fields_set_as_none(
+    db, blank_session, test_masterclass, data, method, optional_field
+):
+    """
+    Tests that when an empty string is passed as the value of an optional
+    model field on Masterclass, that field is set to none.
+    """
+    method = getattr(test_masterclass, method)
+    method(data)
+    assert getattr(test_masterclass, optional_field) is None

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2,9 +2,6 @@ from app.models import MasterclassAttendee, User
 
 import pytest
 
-# Re-write as unit tests
-# Start with adding new objects from scratch instead of starting with factories
-
 
 def test_get_booked_masterclasses_when_not_signed_up():
     """Test empty list is returned if a user has no booked masterclasses."""


### PR DESCRIPTION
This PR adds the ability to add a location when creating a masterclass. A masterclass can either take place online or in person. 

If a user chooses online:
- They will add a url and joining instructions for the masterclass
- These will then be added to the draft masterclass, the id for which is in the session

If a user chooses in person:

- They will be prompted to search for a building, address or postcode
- If their search string matches an existing Location in the database, a list of these Location objects will be returned
- If not, the google places API will be queried using their search string and the first three results will be returned
- If the location they select exists in the database, its id will be added to the draft masterclass in session
- If they select a location from google, this will be added as a new location, and the resulting id will be added to the draft masterclass
- A user is then prompted to enter a room number, floor and any instructions for entering the building

TODO:

1. The search in a SQLite databse is automatically case-insensitive, unlike a postgres database. This means that testing the `Location.return_existing_location_or_none()` method against the current test database is not reflective of the app's behaviour. In my next PR I will be updating the tests to use a postgres database to address this.
2. When the 'add location' journey is finished, a user is redirected to the homepage, in a future PR I will add a task list page which a user would be redirected to instead.